### PR TITLE
Add @JvmStatic to companion object methods for ease of use with other JVM languages.

### DIFF
--- a/examples/testcontainers-java/pom.xml
+++ b/examples/testcontainers-java/pom.xml
@@ -15,7 +15,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <wiremock.testcontainers.version>1.0-alpha-13</wiremock.testcontainers.version>
         <testcontainers.version>1.19.0</testcontainers.version>
-        <extension.version>0.7.0</extension.version>
+        <extension.version>0.8.0</extension.version>
         <wiremock.version>3.3.1</wiremock.version>
         <junit.version>5.10.1</junit.version>
     </properties>

--- a/examples/testcontainers-java/src/test/java/TestSample.java
+++ b/examples/testcontainers-java/src/test/java/TestSample.java
@@ -46,7 +46,7 @@ public class TestSample {
                 WireMock.post(WireMock.urlEqualTo("/graphql"))
                         .andMatching(
                                 GraphqlBodyMatcher.extensionName,
-                                GraphqlBodyMatcher.Companion.withRequest(
+                                GraphqlBodyMatcher.withRequest(
                                         "{ \"query\": \"{ query { name id }}\" }"
                                 )
                         )

--- a/wiremock-graphql-extension/src/main/kotlin/io/github/nilwurtz/GraphqlBodyMatcher.kt
+++ b/wiremock-graphql-extension/src/main/kotlin/io/github/nilwurtz/GraphqlBodyMatcher.kt
@@ -33,6 +33,7 @@ class GraphqlBodyMatcher() : RequestMatcherExtension() {
          */
         @Deprecated("This method will be deleted in a future release. Use withRequestJson instead.")
         @JvmStatic
+        @JvmOverloads
         fun withRequestQueryAndVariables(expectedQuery: String, expectedVariables: String? = null): GraphqlBodyMatcher {
             // Avoid to parse json here. It will be parsed in initExpectedRequestJson
             return GraphqlBodyMatcher().apply {

--- a/wiremock-graphql-extension/src/main/kotlin/io/github/nilwurtz/GraphqlBodyMatcher.kt
+++ b/wiremock-graphql-extension/src/main/kotlin/io/github/nilwurtz/GraphqlBodyMatcher.kt
@@ -32,6 +32,7 @@ class GraphqlBodyMatcher() : RequestMatcherExtension() {
          * @throws InvalidQueryException if the given query is invalid.
          */
         @Deprecated("This method will be deleted in a future release. Use withRequestJson instead.")
+        @JvmStatic
         fun withRequestQueryAndVariables(expectedQuery: String, expectedVariables: String? = null): GraphqlBodyMatcher {
             // Avoid to parse json here. It will be parsed in initExpectedRequestJson
             return GraphqlBodyMatcher().apply {
@@ -52,6 +53,7 @@ class GraphqlBodyMatcher() : RequestMatcherExtension() {
          * @throws InvalidJsonException if the given JSON is malformed.
          * @throws InvalidQueryException if the given query is invalid.
          */
+        @JvmStatic
         fun withRequestJson(expectedJson: String): GraphqlBodyMatcher {
             return GraphqlBodyMatcher().apply {
                 initExpectedRequestJson(expectedJson)
@@ -68,6 +70,7 @@ class GraphqlBodyMatcher() : RequestMatcherExtension() {
          * @throws InvalidJsonException if the given JSON is malformed.
          * @throws InvalidQueryException if the given query is invalid.
          */
+        @JvmStatic
         fun withRequest(expectedJson: String): Parameters {
             // check if the json and query is valid
             expectedJson.toJSONObject().graphqlQueryDocument()


### PR DESCRIPTION
This allows other JVM languages to access the methods with `GraphqlBodyMatcher.with*` rather than `GraphqlBodyMatcher.Companion.with*`.

<!-- Please describe your pull request here. -->

## References

https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.jvm/-jvm-static/

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
