### PR TITLE
Extension registration via service loading.

### DIFF
--- a/wiremock-graphql-extension/Dockerfile
+++ b/wiremock-graphql-extension/Dockerfile
@@ -5,4 +5,3 @@ RUN mvn --batch-mode clean package -Dmaven.test.skip=true
 
 FROM wiremock/wiremock:latest AS wiremock
 COPY --from=build /app/target/wiremock-graphql-extension-*-jar-with-dependencies.jar /var/wiremock/extensions/wiremock-graphql-extension-jar-with-dependencies.jar
-CMD ["--extensions", "io.github.nilwurtz.GraphqlBodyMatcher"]

--- a/wiremock-graphql-extension/src/main/resources/META-INF/services/com.github.tomakehurst.wiremock.extension.Extension
+++ b/wiremock-graphql-extension/src/main/resources/META-INF/services/com.github.tomakehurst.wiremock.extension.Extension
@@ -1,0 +1,1 @@
+io.github.nilwurtz.GraphqlBodyMatcher


### PR DESCRIPTION
Register the extension automatically via service loading rather than explicitly with `--extension`.

## References

- https://wiremock.org/docs/extending-wiremock/#extension-registration-via-service-loading

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
